### PR TITLE
Use primitive types where appropriate

### DIFF
--- a/Blister.Conversion/PlaylistConverter.cs
+++ b/Blister.Conversion/PlaylistConverter.cs
@@ -56,24 +56,26 @@ namespace Blister.Conversion
 
                 if (song.Hash != null)
                 {
-                    map.Type = "hash";
+                    map.Type = BeatmapType.Hash;
 
                     string hash = song.Hash.ToLower();
                     bool isValid = Utils.ValidHash(hash);
                     if (!isValid) throw new InvalidMapHashException(hash);
 
-                    map.Hash = song.Hash.ToLower();
+                    map.Hash = Utils.StringToByteArray(hash);
                 }
                 else if (song.Key != null)
                 {
-                    map.Type = "key";
+                    map.Type = BeatmapType.Key;
 
                     string key = Utils.ParseKey(song.Key);
-                    map.Key = key ?? throw new InvalidMapKeyException(song.Key);
+                    if (key == null) throw new InvalidMapKeyException(song.Key);
+
+                    map.Key = uint.Parse(key);
                 }
                 else if (song.LevelID != null)
                 {
-                    map.Type = "levelID";
+                    map.Type = BeatmapType.LevelID;
                     map.LevelID = song.LevelID;
                 }
 

--- a/Blister.Conversion/Utils.cs
+++ b/Blister.Conversion/Utils.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Blister.Conversion
@@ -42,6 +43,14 @@ namespace Blister.Conversion
         internal static bool ValidHash(string hash)
         {
             return sha1RX.IsMatch(hash);
+        }
+
+        internal static byte[] StringToByteArray(string hex)
+        {
+            return Enumerable.Range(0, hex.Length)
+                             .Where(x => x % 2 == 0)
+                             .Select(x => Convert.ToByte(hex.Substring(x, 2), 16))
+                             .ToArray();
         }
     }
 }

--- a/Blister/Blister.csproj
+++ b/Blister/Blister.csproj
@@ -47,6 +47,7 @@
     <Compile Include="PlaylistLib.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Types\Beatmap.cs" />
+    <Compile Include="Types\BeatmapType.cs" />
     <Compile Include="Types\Playlist.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Blister/Types/Beatmap.cs
+++ b/Blister/Types/Beatmap.cs
@@ -12,7 +12,7 @@ namespace Blister.Types
         /// Beatmap type
         /// </summary>
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public BeatmapType Type { get; set; }
 
         /// <summary>
         /// Date this entry was added to the playlist
@@ -24,13 +24,13 @@ namespace Blister.Types
         /// BeatSaver Key
         /// </summary>
         [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
-        public string Key { get; set; }
+        public int? Key { get; set; }
 
         /// <summary>
         /// Beatmap sha1sum
         /// </summary>
         [JsonProperty("hash", NullValueHandling = NullValueHandling.Ignore)]
-        public string Hash { get; set; }
+        public byte[] Hash { get; set; }
 
         /// <summary>
         /// Beatmap zip as bytes

--- a/Blister/Types/Beatmap.cs
+++ b/Blister/Types/Beatmap.cs
@@ -24,7 +24,7 @@ namespace Blister.Types
         /// BeatSaver Key
         /// </summary>
         [JsonProperty("key", NullValueHandling = NullValueHandling.Ignore)]
-        public int? Key { get; set; }
+        public uint? Key { get; set; }
 
         /// <summary>
         /// Beatmap sha1sum

--- a/Blister/Types/BeatmapType.cs
+++ b/Blister/Types/BeatmapType.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Blister.Types
+{
+    /// <summary>
+    /// Playlist Beatmap Type
+    /// </summary>
+    public enum BeatmapType
+    {
+        /// <summary>
+        /// BeatSaver Key
+        /// </summary>
+        Key = 0,
+
+        /// <summary>
+        /// Beatmap Hash
+        /// </summary>
+        Hash = 1,
+
+        /// <summary>
+        /// Compressed Beatmap Zip
+        /// </summary>
+        Zip = 2,
+
+        /// <summary>
+        /// Beatmap Level ID
+        /// </summary>
+        LevelID = 3,
+    }
+}

--- a/Blister/Types/BeatmapType.cs
+++ b/Blister/Types/BeatmapType.cs
@@ -5,7 +5,7 @@ namespace Blister.Types
     /// <summary>
     /// Playlist Beatmap Type
     /// </summary>
-    public enum BeatmapType
+    public enum BeatmapType : uint
     {
         /// <summary>
         /// BeatSaver Key

--- a/SPEC.md
+++ b/SPEC.md
@@ -21,17 +21,17 @@ The extension for playlist files is `.blist`
 | `type` | `int enum` | See [Beatmap Types](#beatmap-types) for valid enum values |
 | `dateAdded` | `date` | Date when this map was added to the playlist |
 | `key` | `int` | Only present when `type == "key"` |
-| `hash` | `binary` | Only present when `type == "hash"` |
+| `hash` | `byte[20]` | Only present when `type == "hash"` |
 | `bytes` | `binary` | Only present when `type == "zip"` |
 | `levelID` | `string` | Only present when `type == "levelID"` |
 
 ### Beatmap Types
 | Type | Usage |
 | - | - |
-| `1` | Uses a [BeatSaver key](#beatsaver-key-format) to reference a beatmap |
-| `2` | Uses a [Beatmap hash](#beatmap-hash-format) to reference a beatmap |
-| `3` | Embeds a [Beatmap zip](#beatmap-zips) in the playlist |
-| `4` | Uses a Level ID to reference a beatmap.<br />For custom beatmaps this is derived from the hash, so it is preferred to use `hash`<br />This is best used to reference OST beatmaps. |
+| `0` | Uses a [BeatSaver key](#beatsaver-key-format) to reference a beatmap |
+| `1` | Uses a [Beatmap hash](#beatmap-hash-format) to reference a beatmap |
+| `2` | Embeds a [Beatmap zip](#beatmap-zips) in the playlist |
+| `3` | Uses a Level ID to reference a beatmap.<br />For custom beatmaps this is derived from the hash, so it is preferred to use `hash`<br />This is best used to reference OST beatmaps. |
 
 The enum system was adopted to enable the extension of this specification to add more map referencing systems. **Additional types may be added at a later date.**
 
@@ -42,7 +42,7 @@ BeatSaver keys are integers. They use a lowercased hex-encoded representation on
 To convert from old to new, take the last number in the old key (after the `-`).
 
 ### Beatmap Hash Format
-Beatmap hashes are calculated using the `sha1` hashing algorithm. Therefore, they are always 20 bytes long.
+Beatmap hashes are calculated using the `sha1` hashing algorithm.
 
 To calculate beatmap hashes, concatenate `info.dat` and every difficulty `.dat` in the order they appear in `info.dat`, then hash those concatenated bytes.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,9 +18,9 @@ The extension for playlist files is `.blist`
 ### Beatmap
 | Key | Type | Extra Info |
 | - | - | - |
-| `type` | `int enum` | See [Beatmap Types](#beatmap-types) for valid enum values |
+| `type` | `uint enum` | See [Beatmap Types](#beatmap-types) for valid enum values |
 | `dateAdded` | `date` | Date when this map was added to the playlist |
-| `key` | `int` | Only present when `type == "key"` |
+| `key` | `uint` | Only present when `type == "key"` |
 | `hash` | `byte[20]` | Only present when `type == "hash"` |
 | `bytes` | `binary` | Only present when `type == "zip"` |
 | `levelID` | `string` | Only present when `type == "levelID"` |

--- a/SPEC.md
+++ b/SPEC.md
@@ -18,31 +18,31 @@ The extension for playlist files is `.blist`
 ### Beatmap
 | Key | Type | Extra Info |
 | - | - | - |
-| `type` | `string enum` | See [Beatmap Types](#beatmap-types) for valid enum values |
+| `type` | `int enum` | See [Beatmap Types](#beatmap-types) for valid enum values |
 | `dateAdded` | `date` | Date when this map was added to the playlist |
-| `key` | `string` | Only present when `type == "key"` |
-| `hash` | `string` | Only present when `type == "hash"` |
+| `key` | `int` | Only present when `type == "key"` |
+| `hash` | `binary` | Only present when `type == "hash"` |
 | `bytes` | `binary` | Only present when `type == "zip"` |
 | `levelID` | `string` | Only present when `type == "levelID"` |
 
 ### Beatmap Types
 | Type | Usage |
 | - | - |
-| `key` | Uses a [BeatSaver key](#beatsaver-key-format) to reference a beatmap |
-| `hash` | Uses a [Beatmap hash](#beatmap-hash-format) to reference a beatmap |
-| `zip` | Embeds a [Beatmap zip](#beatmap-zips) in the playlist |
-| `levelID` | Uses a Level ID to reference a beatmap.<br />For custom beatmaps this is derived from the hash, so it is preferred to use `hash`<br />This is best used to reference OST beatmaps. |
+| `1` | Uses a [BeatSaver key](#beatsaver-key-format) to reference a beatmap |
+| `2` | Uses a [Beatmap hash](#beatmap-hash-format) to reference a beatmap |
+| `3` | Embeds a [Beatmap zip](#beatmap-zips) in the playlist |
+| `4` | Uses a Level ID to reference a beatmap.<br />For custom beatmaps this is derived from the hash, so it is preferred to use `hash`<br />This is best used to reference OST beatmaps. |
 
 The enum system was adopted to enable the extension of this specification to add more map referencing systems. **Additional types may be added at a later date.**
 
 ## Addendum
 ### BeatSaver Key Format
-BeatSaver keys are lowercased hex-encoded integers. When converting from old playlists, you may encounter old BeatSaver keys in the format `XXX-XXX` where `X` represents a decimal digit.
+BeatSaver keys are integers. They use a lowercased hex-encoded representation on BeatSaver. When converting from old playlists, you may encounter old BeatSaver keys in the format `XXX-XXX` where `X` represents a decimal digit.
 
-To convert from old to new, take the last number in the old key (after the `-`) and convert from decimal to hex.
+To convert from old to new, take the last number in the old key (after the `-`).
 
 ### Beatmap Hash Format
-Beatmap hashes are calculated using the `sha1` hashing algorithm, in lowercased hex format.
+Beatmap hashes are calculated using the `sha1` hashing algorithm. Therefore, they are always 20 bytes long.
 
 To calculate beatmap hashes, concatenate `info.dat` and every difficulty `.dat` in the order they appear in `info.dat`, then hash those concatenated bytes.
 


### PR DESCRIPTION
Since BSON is a binary format, there are no readability advantages justifying the use of strings where primitive types would be more appropriate.

* `type` switches from `string` to `int`
* `key` switches from `string` to `int`
* `hash` switches from `string` to `binary`

Switching to those types

1. reduces the file size, especially for large playlists.
2. makes implementation of the specification in lower level languages and FFI easier.

Note that I didn't update the code to respect those changes, I will do it if requested once the changes are accepted.